### PR TITLE
feat(os_spec.rb): disable os-08 entropy check

### DIFF
--- a/controls/os_spec.rb
+++ b/controls/os_spec.rb
@@ -224,14 +224,15 @@ control 'os-07' do
   end
 end
 
-control 'os-08' do
-  impact 1.0
-  title 'Entropy'
-  desc 'Check system has enough entropy - greater than 1000'
-  describe file('/proc/sys/kernel/random/entropy_avail').content.to_i do
-    it { should >= 1000 }
-  end
-end
+# Disable os-08: entropy behaviour has changed in the linux kernel
+# control 'os-08' do
+#   impact 1.0
+#   title 'Entropy'
+#   desc 'Check system has enough entropy - greater than 1000'
+#   describe file('/proc/sys/kernel/random/entropy_avail').content.to_i do
+#     it { should >= 1000 }
+#   end
+# end
 
 control 'os-09' do
   impact 1.0


### PR DESCRIPTION
As in upstream, we should remove the os-08 entropy test
https://github.com/dev-sec/linux-baseline/issues/176